### PR TITLE
Add SerpApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated list of top best directories and platforms to launch and promote your 
 - [Zapier Directory](https://zapier.com/apps) - Tools integrated with Zapier.
 - [B2B Stack](https://www.b2bstack.com.br) - SaaS tools for B2B use.
 - [TapRefer](https://www.taprefer.com) - Biggest directory of affiliate programs.
+- [SerpApi](https://serpapi.com) - API to scrape search engines.
 
 ---
 


### PR DESCRIPTION
Add SerpApi to specialized SaaS directories.

We're focusing ourself on scraping search engine results.