### PR TITLE
Add SearchApi to "Specialized SaaS Directories"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated list of top best directories and platforms to launch and promote your 
 - [Zapier Directory](https://zapier.com/apps) - Tools integrated with Zapier.
 - [B2B Stack](https://www.b2bstack.com.br) - SaaS tools for B2B use.
 - [TapRefer](https://www.taprefer.com) - Biggest directory of affiliate programs.
+- [SearchApi](https://www.searchapi.io/) - Real-time SERP API, offering data from engines like Google, Bing, Baidu, and more.
 
 ---
 


### PR DESCRIPTION
Add [SearchApi](https://www.searchapi.io/) to the "Specialized SaaS Directories" section.

SearchApi provides real-time SERP data across major search engines, including Google, Bing, Baidu, and more.