### PR TITLE
Add GEOScore to AI Directories section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A More Complete List of AI Directories are available on **[best-of-ai/ai-directo
 - [AI For Developers](https://aifordevelopers.org) - Access curated AI SDKs, copilots, and APIs to supercharge your development workflow.
 - [There's an AI](https://theresanai.com) - The best AI Tools Directory
 - [Future Tools](https://futuretools.io) - Stay up-to-date on AI Tools
+- [GEOScore](https://geoscoreai.com) - Free AI search visibility scanner for checking if your site can be found by ChatGPT, Perplexity, Claude & Gemini
 - [Toolkitly](https://www.toolkitly.com) – Your Go-To Platform for Tech Tool Discussions, Innovations & Real-Time Updates!
 
 


### PR DESCRIPTION
## Summary

Adding [GEOScore](https://geoscoreai.com) to the **AI Directories** section.

GEOScore is a free AI search visibility scanner that checks if websites can be found by AI search engines (ChatGPT, Perplexity, Claude, Gemini). It's a useful directory/tool for SaaS founders to ensure their products are discoverable in AI-powered search.

Fits well alongside other AI tool directories like Altern, Future Tools, and There's an AI.