### PR TITLE
Add OpenSourceProjects.cc to Global SaaS Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ A More Complete List of AI Directories are available on **[best-of-ai/ai-directo
 - [CrozDesk](https://crozdesk.com/) - SaaS reviews and rankings.
 - [SaaS Genius](https://saasgenius.com/) - Discover and compare SaaS tools.
 - [Open SaaS Directory](https://opensaas.directory/) - Open source and self-hosted SaaS alternatives.
+- [OpenSourceProjects.cc](https://opensourceprojects.cc) - Discover open source alternatives to popular commercial SaaS, organized by category.
 - [Software Select](https://softwareselecthq.com/) - Discover SAAS tools.
 
 ---


### PR DESCRIPTION
## What

Adding OpenSourceProjects.cc to the Global SaaS Directories section.

## Why

OpenSourceProjects.cc is a discovery platform that catalogs open source projects with categorized alternatives to popular commercial SaaS products like Notion, Slack, Figma, etc.

It's similar in nature to [Open SaaS Directory](https://opensaas.directory/) which is already listed in the same section — both help users find open source alternatives to mainstream SaaS tools.

## Notes

- 70+ projects already cataloged, growing weekly
- Free, no signup, no ads
- Single line addition under "Global SaaS Directories"