### PR TITLE
Add CazaProducto

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A curated list of top best directories and platforms to launch and promote your 
 - [SideProjectors](https://www.sideprojectors.com/) - A hub for SaaS side projects.
 - [IndieProducts.io](https://www.indieproducts.io/) - A directory for Indie products, Solopreneurs and Buildinpublic makers.
 - [PeerPush](https://peerpush.net/) - Build in Public, Discover & Share Innovative Products
-- [CazaProducto](https://cazaproducto.com/) - Product Hunt for LatAm, discover and launch products built by Latin American makers.
+- [CazaProducto](https://cazaproducto.com/) - The Product Hunt of Latin America, makers launch and get upvoted by the region's community.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A curated list of top best directories and platforms to launch and promote your 
 - [SideProjectors](https://www.sideprojectors.com/) - A hub for SaaS side projects.
 - [IndieProducts.io](https://www.indieproducts.io/) - A directory for Indie products, Solopreneurs and Buildinpublic makers.
 - [PeerPush](https://peerpush.net/) - Build in Public, Discover & Share Innovative Products
+- [CazaProducto](https://cazaproducto.com/) - Product Hunt for LatAm, discover and launch products built by Latin American makers.
 
 ---
 


### PR DESCRIPTION
Adding CazaProducto (https://cazaproducto.com) under Startup and Maker Communities — it's a Product Hunt style launch platform focused on the Latin American maker scene.