### PR TITLE
Add Open Source Projects to Specialized SaaS Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated list of top best directories and platforms to launch and promote your 
 - [Zapier Directory](https://zapier.com/apps) - Tools integrated with Zapier.
 - [B2B Stack](https://www.b2bstack.com.br) - SaaS tools for B2B use.
 - [TapRefer](https://www.taprefer.com) - Biggest directory of affiliate programs.
+- [Open Source Projects](https://opensourceprojects.cc/) - Directory of open source projects and open source alternatives to proprietary software.
 
 ---
 


### PR DESCRIPTION
Adds [Open Source Projects](https://opensourceprojects.cc/) under **Specialized SaaS Directories** — a directory of open source projects and open source alternatives to proprietary software. Matches the existing entry format.